### PR TITLE
Correct method declaration for object

### DIFF
--- a/decks/javascript.html
+++ b/decks/javascript.html
@@ -3305,7 +3305,7 @@
             <main>
               <pre class="" data-id="code"><code data-trim class="language-javascript" data-line-numbers=""><script type="text/template">
                 let obj = {
-                  function func() {
+                  func() {
                     console.log(this);
                   }
                 }


### PR DESCRIPTION
Fixes SyntaxError: missing : after property id :+1: 